### PR TITLE
bundle exec rake db:create:allでのエラーが発生したので修正

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -21,7 +21,6 @@ development:
   pool: 5
   username: <%= ENV['USER'] %>
   password:
-  host: localhost
 
   # Connect on a TCP socket. Omitted by default since the client uses a
   # domain socket that doesn't need configuration. Windows does not have
@@ -51,12 +50,11 @@ test:
   pool: 5
   username: <%= ENV['USER'] %>
   password:
-  host: localhost
 
 production:
   adapter: postgresql
   encoding: unicode
   database: daitokaiet_production
   pool: 5
-  username: daitokaiet
+  username: <%= ENV['USER'] %>
   password:


### PR DESCRIPTION
bundle exec rake db:create:allでdaitokaiet_developmentとdaitokaiet_testのデータベースが作られない可能性があった問題を修正。daitokaiet_productionデータベースのユーザを固定値から実際のユーザに修正
