### PR TITLE
Twitter でつぶやくときのスペーシングを変更

### DIFF
--- a/app/models/record.rb
+++ b/app/models/record.rb
@@ -26,7 +26,7 @@ class Record < ActiveRecord::Base
   end
 
   def update_twitter
-    self.user.twitter_client.update("目標体重まであと#{self.to_goal.round(2)}kg #daitokaiet #{self.comment}#{if self.comment.to_s != '' then ' ' end}| #{target_date.to_s}")
+    self.user.twitter_client.update("目標体重まであと#{self.to_goal.round(2)}kg #daitokaiet#{" #{self.comment}" if self.comment.present?} | #{target_date.to_s}")
   rescue
     logger.info('tweet失敗 at update_twitter')
   end


### PR DESCRIPTION
Twitter でつぶやくときのスペーシングがとても気になったので変更してみました。
- コメントがないときはスペースが1つにした。
- 日付の "|" の後にスペースを1つ入れた。

どうでしょうか? もしよろしければ取り込まれたく存じます。よろしくお願い申し上げます。

末筆ながら、rubyらしい書き方に変更していただければ幸いです。合わせてよろしくお願い申し上げます。
